### PR TITLE
Improved tap accessibility and added reset from code.

### DIFF
--- a/MAConfirmButton/MAConfirmButton.h
+++ b/MAConfirmButton/MAConfirmButton.h
@@ -18,6 +18,8 @@
 	CALayer *colorLayer;
 	CALayer *darkenLayer;
 	UIButton *cancelOverlay;
+    BOOL ensureAccessibleTouch;
+    CGRect touchBounds;
 }
 
 + (MAConfirmButton *)buttonWithTitle:(NSString *)titleString confirm:(NSString *)confirmString;
@@ -27,6 +29,7 @@
 - (void)disableWithTitle:(NSString *)disabledString;
 - (void)setAnchor:(CGPoint)anchor;
 - (void)setTintColor:(UIColor *)color;
+- (void)setEnsureAccessibleTouch:(BOOL)flag;
 - (void)reset;
 
 @end

--- a/MAConfirmButton/MAConfirmButton.h
+++ b/MAConfirmButton/MAConfirmButton.h
@@ -27,5 +27,6 @@
 - (void)disableWithTitle:(NSString *)disabledString;
 - (void)setAnchor:(CGPoint)anchor;
 - (void)setTintColor:(UIColor *)color;
+- (void)reset;
 
 @end

--- a/MAConfirmButton/MAConfirmButton.m
+++ b/MAConfirmButton/MAConfirmButton.m
@@ -290,4 +290,9 @@
 	self.selected = NO;
 }
 
+- (void)reset {
+    confirmed = NO;
+    [self cancel];
+}
+
 @end

--- a/MAConfirmButton/MAConfirmButton.m
+++ b/MAConfirmButton/MAConfirmButton.m
@@ -261,7 +261,8 @@
 - (void)touchesEnded:(NSSet *)touches withEvent:(UIEvent *)event{
 	
 	if(!disabled && !confirmed){
-		if(!CGRectContainsPoint(self.frame, [[touches anyObject] locationInView:self.superview])){ //TouchUpOutside (Cancelled Touch)
+		if(!CGRectContainsPoint(touchBounds, [[touches anyObject] locationInView:self])){ 
+            //TouchUpOutside (Cancelled Touch)
 			[self lighten];
 			[super touchesCancelled:touches withEvent:event];
 		}else if(selected){
@@ -293,6 +294,40 @@
 - (void)reset {
     confirmed = NO;
     [self cancel];
+}
+
+#pragma mark - Accessible touch
+
+- (void)updateTouchBounds {
+    CGRect bounds = self.frame; 
+    bounds.origin.x = bounds.origin.y = 0;
+    if (ensureAccessibleTouch) {
+        if (bounds.size.width < 44) {
+            CGFloat delta = 44 - bounds.size.width;
+            bounds.origin.x -= delta / 2;
+            bounds.size.width += delta;
+        }
+        if (bounds.size.height < 44) {
+            CGFloat delta = 44 - bounds.size.height;
+            bounds.origin.y -= delta / 2;
+            bounds.size.height += delta;
+        }
+    }
+    touchBounds = bounds;
+}
+
+- (void)setEnsureAccessibleTouch:(BOOL)flag {
+    ensureAccessibleTouch = flag;
+    [self updateTouchBounds];
+}
+
+- (void)setFrame:(CGRect)frame {
+    [super setFrame:frame];
+    [self updateTouchBounds];
+}
+
+- (UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event {
+    return CGRectContainsPoint(touchBounds, point) ? self : nil;
 }
 
 @end

--- a/Sample/SampleViewController.m
+++ b/Sample/SampleViewController.m
@@ -52,11 +52,17 @@
 	MAConfirmButton *disabledButton = [MAConfirmButton buttonWithDisabledTitle:@"DISABLED"];
 	[disabledButton setAnchor:CGPointMake(270, 150)];		
 	[self.view addSubview:disabledButton];
+    
+	MAConfirmButton *accessibleButton = [MAConfirmButton buttonWithTitle:@"Accessible Touch" confirm:@"Easier? Isn't it?"];
+	[accessibleButton addTarget:self action:@selector(confirmAction:) forControlEvents:UIControlEventTouchUpInside];
+	[accessibleButton setAnchor:CGPointMake(270, 200)];
+    [accessibleButton setEnsureAccessibleTouch:YES];
+	[self.view addSubview:accessibleButton];
 	
 	resetButton = [MAConfirmButton buttonWithTitle:@"Reset" confirm:@"Are you sure?"];
 	[resetButton addTarget:self action:@selector(resetUI) forControlEvents:UIControlEventTouchUpInside];
 	[resetButton setTintColor:[UIColor colorWithRed:0.694 green:0.184 blue:0.196 alpha:1]];
-	[resetButton setAnchor:CGPointMake(270, 250)];
+	[resetButton setAnchor:CGPointMake(270, 300)];
 	[self.view addSubview:resetButton];
 	
 }


### PR DESCRIPTION
Hi, I've used MAConfirmButton in a project. Thanks.
I've added 2 more features:
- be able to reset button state to normal state from the code 
- make button handle taps in at least 44 pixels area, while staying having the same size visually (AppStore's button does that)
