### PR TITLE
Confirmless Button

### DIFF
--- a/MAConfirmButton/MAConfirmButton.m
+++ b/MAConfirmButton/MAConfirmButton.m
@@ -313,10 +313,13 @@
             [cancelOverlay removeFromSuperview];
             cancelOverlay = nil;
             [super touchesEnded:touches withEvent:event];
+        }else if(!confirm){
+          [self lighten];
+          [super touchesEnded:touches withEvent:event];
         }else{
             [self lighten];		
             self.selected = YES;            
-            if(!cancelOverlay){		                
+            if(!cancelOverlay && confirm){		                
                 cancelOverlay = [UIButton buttonWithType:UIButtonTypeCustom];
                 [cancelOverlay setFrame:CGRectMake(0, 0, 1024, 1024)];
                 [cancelOverlay addTarget:self action:@selector(cancel) forControlEvents:UIControlEventTouchDown];

--- a/Sample/SampleViewController.m
+++ b/Sample/SampleViewController.m
@@ -64,11 +64,26 @@
   [resetButton setTintColor:[UIColor colorWithRed:0.694 green:0.184 blue:0.196 alpha:1]];
   [resetButton setAnchor:CGPointMake(200, 250)];
   [self.view addSubview:resetButton];
+
+  
+  MAConfirmButton *confirmlessButton = [MAConfirmButton buttonWithTitle:@"Confirmless" confirm:nil];
+  [confirmlessButton addTarget:self action:@selector(showAlert) forControlEvents:UIControlEventTouchUpInside];
+  [confirmlessButton setTintColor:[UIColor colorWithRed:0.439 green:0.741 blue:0.314 alpha:1.]];
+  [confirmlessButton setAnchor:CGPointMake(200, 300)];
+  [self.view addSubview:confirmlessButton];
+
   
 }
 
 - (void)resetUI{
   [self setupView];
+}
+
+- (void)showAlert{
+  UIAlertView *alertView = [[UIAlertView alloc] initWithTitle:@"Alert" message:@"Button tapped" delegate:nil cancelButtonTitle:@"OK" otherButtonTitles:nil];
+  
+  [alertView show];
+  [alertView release];
 }
 
 - (void)confirmAction:(id)sender{


### PR DESCRIPTION
I know this pull request is completely COUNTER to the point of the project, but the MAConfirmButton just looks so nice I wanted to use it as a regular button too.

The following pull request adds the ability to have a confirmless button. Just pass `nil` into confirm: when creating the button, and the button will act like a normal button, but beautiful.
