### PR TITLE
Fix overidded color method

### DIFF
--- a/MAConfirmButton/MAConfirmButton.m
+++ b/MAConfirmButton/MAConfirmButton.m
@@ -272,7 +272,7 @@
 }
 
 - (void)setTintColor:(UIColor *)color{
-    self.tint = [UIColor colorWithHue:color.hue saturation:color.saturation+0.15 brightness:color.brightness alpha:1];
+    self.tint = [UIColor newColorWithHue:color.hue saturation:color.saturation+0.15 brightness:color.brightness alpha:1];
     colorLayer.backgroundColor = tint.CGColor;
     [self setNeedsDisplay];
 }

--- a/MAConfirmButton/UIColor-Expanded.h
+++ b/MAConfirmButton/UIColor-Expanded.h
@@ -78,7 +78,7 @@
 + (NSDictionary *)namedCrayons;
 
 // Build a color with the given HSB values
-+ (UIColor *)colorWithHue:(CGFloat)hue saturation:(CGFloat)saturation brightness:(CGFloat)brightness alpha:(CGFloat)alpha;
++ (UIColor *)newColorWithHue:(CGFloat)hue saturation:(CGFloat)saturation brightness:(CGFloat)brightness alpha:(CGFloat)alpha;
 
 // Low level conversions between RGB and HSL spaces
 + (void)hue:(CGFloat)h saturation:(CGFloat)s brightness:(CGFloat)v toRed:(CGFloat *)r green:(CGFloat *)g blue:(CGFloat *)b;

--- a/MAConfirmButton/UIColor-Expanded.m
+++ b/MAConfirmButton/UIColor-Expanded.m
@@ -349,7 +349,7 @@ static NSLock *crayolaNameCacheLock;
 	if (h > 360.f) h -= 360.0f;
 	
 	// Create a color in RGB
-	return [UIColor colorWithHue:h saturation:s brightness:v alpha:a];
+	return [UIColor newColorWithHue:h saturation:s brightness:v alpha:a];
 }
 
 // Pick two colors more colors such that all three are equidistant on the color wheel
@@ -540,7 +540,7 @@ static NSLock *crayolaNameCacheLock;
 	return crayolaNameCache;
 }
 
-+ (UIColor *)colorWithHue:(CGFloat)hue saturation:(CGFloat)saturation brightness:(CGFloat)brightness alpha:(CGFloat)alpha {
++ (UIColor *)newColorWithHue:(CGFloat)hue saturation:(CGFloat)saturation brightness:(CGFloat)brightness alpha:(CGFloat)alpha {
 	// Convert hsb to rgb
 	CGFloat r,g,b;
 	[self hue:hue saturation:saturation brightness:brightness toRed:&r green:&g blue:&b];


### PR DESCRIPTION
This is a pretty terrible fix, but the fixed method's implementation just does not do what the cocoa provided method does.

This at least preserves what's happening.

This fixes #8.
