### PR TITLE
Fixes a typo in the README which threw confusion on whether the button w...

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -21,7 +21,7 @@ MAConfirmButton *confirmButton = [MAConfirmButton buttonWithTitle:@"Button Title
 h3. Init
 
 <pre>
-+ (MAConfirmButton *)buttonWithTitle:(NSString *)disabledString confirm:(NSString *)confirmString;
++ (MAConfirmButton *)buttonWithTitle:(NSString *)titleString confirm:(NSString *)confirmString;
 + (MAConfirmButton *)buttonWithDisabledTitle:(NSString *)disabledString;
 </pre>
 


### PR DESCRIPTION
...as initialized with a title string, or a disabled string, and the confirm string.
