### PR TITLE
Change the return type of the convenience initialization methods

### DIFF
--- a/MAConfirmButton/MAConfirmButton.m
+++ b/MAConfirmButton/MAConfirmButton.m
@@ -39,12 +39,12 @@
     [super dealloc];
 }
 
-+ (MAConfirmButton *)buttonWithTitle:(NSString *)titleString confirm:(NSString *)confirmString{	
++ (id)buttonWithTitle:(NSString *)titleString confirm:(NSString *)confirmString{	
     MAConfirmButton *button = [[[super alloc] initWithTitle:titleString confirm:confirmString] autorelease];	
     return button;
 }
 
-+ (MAConfirmButton *)buttonWithDisabledTitle:(NSString *)disabledString{	
++ (id)buttonWithDisabledTitle:(NSString *)disabledString{	
     MAConfirmButton *button = [[[super alloc] initWithDisabledTitle:disabledString] autorelease];	
     return button;
 }


### PR DESCRIPTION
Right now, if you want to subclass MAConfirmButton you can't use the autoreleased class methods because the types conflict.
